### PR TITLE
Add functional header to CPPUtils.h

### DIFF
--- a/runtime/src/support/CPPUtils.h
+++ b/runtime/src/support/CPPUtils.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include <functional>
 
 namespace antlrcpp {
 


### PR DESCRIPTION
On my system (Fedora 36, G++ 12.1.1), the inclusion of `std::function` requires the `<functional>` header, so include it in `CPPUtils.h`.